### PR TITLE
Make extension start on startup, clean up, add resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="./images/claude-debugs-for-you.png" width="64" height="64" alt="description" align="center"> Claude Debugs For You
 
 
-[![Badge](https://img.shields.io/badge/Visual%20Studio%20Marketplace-0.0.5-blue.svg)](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
+[![Badge](https://img.shields.io/badge/Visual%20Studio%20Marketplace-0.0.4-blue.svg)](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
 
 ### Enable Claude (or any other LLM) to interactively debug your code
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ It's language-agnostic, assuming debugger console support and valid launch.json 
 2. Install the extension
   - If using `.vsix` directly, go to the three dots in "Extensions" in VS Code and choose "Install from VSIX..."
 3. Open a project containing a `.vscode/launch.json` with the first configuration setup to debug a specific file with `${file}`.
+4. On startup, a popup will show that the debug server started and a path to the node binary
+  - This can be disabled in settings (e.g. once you've done it the first time or if you're using /sse)
 
 ### If using node process based method (required for Claude Desktop)
-4. Execute "Start MCP Debug Server" (A popup will show that it started: copy the path to `mcp-debug.js`)
+5. Copy the path of the node binary to `mcp-debug.js` in the popup
 
 <img width="384" alt="image" src="https://github.com/user-attachments/assets/5de31d62-32e5-4eac-83f1-cd6bacc2ab7d" />
 
-5. Paste the following (BUT UPDATE THE PATH!) in your `claude_desktop_config.json` or edit accordingly if you use other MCP servers
+5. Paste the following (BUT UPDATE THE PATH TO THE COPIED ONE!) in your `claude_desktop_config.json` or edit accordingly if you use other MCP servers
 
 ```
 {
@@ -45,8 +47,8 @@ It's language-agnostic, assuming debugger console support and valid launch.json 
 ### If using `/sse` based method (e.g. Cursor)
 4. Add the MCP server using the server URL of "http://localhost:4711/sse", or whatever port you setup in settings.
   - You may need to hit "refresh" depending on client: this is required in Cursor
-6. You're ready to debug
-7. See [Run  an Example](#run-an-example) below.
+5. You're ready to debug
+6. See [Run  an Example](#run-an-example) below.
 
 ## Contributing
 
@@ -88,13 +90,13 @@ https://github.com/user-attachments/assets/3a0a879d-2db7-4a3f-ab43-796c22a0f1ef
   }
   ```
 
-  When you open VS Code, (like other instructions) make sure to run `Start MCP Debug Server` to start it up, then restart continue plugin (go to plugins and disable/enable).
-
-  (This is annoying and should be fixed... but MCP fails to parse properly if the server can't be reached)
-
   You'll also need to choose a model capable of using tools.
 
   When the list of tools pops up, make sure to click "debug" in the list of your tools, and set it to be "Automatic".
+
+  ### Troubleshooting
+
+  If you are seeing MCP errors in continue, try disabling / re-enabling the continue plugin
 
 </details>
 
@@ -109,10 +111,9 @@ https://github.com/user-attachments/assets/ef6085f7-11a2-4eea-bb60-b5a54873b5d5
 
 ## Developing
 
-- Cline / Open this repo with VS Code
+- Clone / Open this repo with VS Code
 - Run `npm run install` and `npm run compile`
 - Hit "run" which will open a new VSCode
-    - Run the command in VS Code: "Start MCP Debug Server"
 - Otherwise same as "Getting Started applies"
 - To rebuild, `npm run compile`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="./images/claude-debugs-for-you.png" width="64" height="64" alt="description" align="center"> Claude Debugs For You
 
 
-[![Badge](https://img.shields.io/badge/Visual%20Studio%20Marketplace-0.0.4-blue.svg)](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
+[![Badge](https://img.shields.io/badge/Visual%20Studio%20Marketplace-0.0.5-blue.svg)](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
 
 ### Enable Claude (or any other LLM) to interactively debug your code
 
@@ -25,7 +25,7 @@ It's language-agnostic, assuming debugger console support and valid launch.json 
 
 <img width="384" alt="image" src="https://github.com/user-attachments/assets/5de31d62-32e5-4eac-83f1-cd6bacc2ab7d" />
 
-5. Paste the following (BUT UPDATE THE PATH TO THE COPIED ONE!) in your `claude_desktop_config.json` or edit accordingly if you use other MCP servers
+6. Paste the following (BUT UPDATE THE PATH TO THE COPIED ONE!) in your `claude_desktop_config.json` or edit accordingly if you use other MCP servers
 
 ```
 {
@@ -40,15 +40,20 @@ It's language-agnostic, assuming debugger console support and valid launch.json 
 }
 ```
 
-6. Start Claude desktop (or other MCP client)
-7. You're ready to debug
-8. See [Run  an Example](#run-an-example) below.
+7. Start Claude desktop (or other MCP client)
+  - Note: You may need to restart it, if it was already running.
+  - You can skip this step if using Continue/Cursor or other built-in to VS Code
 
 ### If using `/sse` based method (e.g. Cursor)
 4. Add the MCP server using the server URL of "http://localhost:4711/sse", or whatever port you setup in settings.
   - You may need to hit "refresh" depending on client: this is required in Cursor
-5. You're ready to debug
-6. See [Run  an Example](#run-an-example) below.
+5. Start MCP client
+  - Note: You may need to restart it, if it was already running.
+  - You can skip this step if using Continue/Cursor or other built-in to VS Code
+
+### You're ready to debug!
+
+See [Run  an Example](#run-an-example) below, and/or watch a demo video.
 
 ## Contributing
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -72,15 +72,39 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
 });
 
+function sleep(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 async function main() {
     try {
         const transport = new StdioServerTransport();
         await server.connect(transport);
         console.error("MCP Debug Server running");
+        return true;
     } catch (error) {
         console.error("Error starting server:", error);
-        process.exit(1);
+        return false;
     }
 }
 
-main();
+// Only try up to 5 times
+const MAX_RETRIES = 5;
+
+// Wait 12s before each subsequent check
+const TIMEOUT = 12000;
+
+// Wait 500ms before first check
+const INITIAL_DELAY = 500;
+
+await sleep(INITIAL_DELAY);
+
+for (let i = 0; i < MAX_RETRIES; i++) {
+    const success = await main();
+    if (success) {
+        break;
+    }
+    await sleep(TIMEOUT);
+}

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "vscode-mcp-debug.restart",
-        "title": "Start MCP Debug Server"
+        "title": "Restart MCP Debug Server"
       }
     ],
     "configuration": {
@@ -29,6 +31,11 @@
           "type": "number",
           "default": 4711,
           "description": "Port number for the debug server"
+        },
+        "mcpDebug.showServerPathOnStartup": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show the server path on startup"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,17 +21,24 @@ export function activate(context: vscode.ExtensionContext) {
 
     const config = vscode.workspace.getConfiguration('mcpDebug');
     const server = new DebugServer(config.get<number>('port') ?? 4711);
-    server.start().catch(err => {
-        vscode.window.showErrorMessage(`Failed to start debug server: ${err.message}`);
-    });
+
+    function startServer() {
+        server.start().then(() => {
+            if (config.get<boolean>("showServerPathOnStartup")) {
+                vscode.window.showInformationMessage(`MCP Debug server started: ${mcpServerPath}`);
+            }
+        }).catch(err => {
+            vscode.window.showErrorMessage(`Failed to start debug server: ${err.message}`);
+        });
+    }
+
+    startServer();
 
     let disposable = vscode.commands.registerCommand('vscode-mcp-debug.restart', () => {
         server.stop().catch(err => {
             vscode.window.showErrorMessage(`Failed to stop debug server: ${err.message}`);
         }).then(() => {
-            server.start().catch(err => {
-                vscode.window.showErrorMessage(`Failed to restart debug server: ${err.message}`);
-            });
+            startServer();
         });
     });
 


### PR DESCRIPTION
- Automatically starts on vs code finishing initializing
- Lots of general clean up and improvements to readme
- Add some resilience to node-process based method (retry logic)