### PR TITLE
Improve launching debug session

### DIFF
--- a/src/debug-server.ts
+++ b/src/debug-server.ts
@@ -355,11 +355,15 @@ export class DebugServer extends EventEmitter implements DebugServerEvents {
             });
         }
 
-        // Start debugging using the configured launch configuration
-        await vscode.debug.startDebugging(workspaceFolder, config);
+        // Check if we're already debugging
+        let session = vscode.debug.activeDebugSession;
+        if (! session) {
+            // Start debugging using the configured launch configuration
+            await vscode.debug.startDebugging(workspaceFolder, config);
 
-        // Wait for session to be available
-        const session = await this.waitForDebugSession();
+            // Wait for session to be available
+            session = await this.waitForDebugSession();
+        }
 
         // Check if we're at a breakpoint
         try {


### PR DESCRIPTION
Sometimes I have to start debugging before using MCP tool such as build-in web server. So I think we should check vscode has an active session before starting a new one.