### PR TITLE
Include threadId in continue request for Unity debugger compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-debugs-for-you",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-debugs-for-you",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.4.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-debugs-for-you",
   "displayName": "Claude Debugs for You",
   "description": "Enable an MCP Client, such as Claude Desktop to directly debug code with breakpoints",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "https://github.com/jasonjmcghee/claude-debugs-for-you",
   "author": "Jason McGhee",
   "publisher": "JasonMcGhee",

--- a/src/debug-server.ts
+++ b/src/debug-server.ts
@@ -461,7 +461,13 @@ export class DebugServer extends EventEmitter implements DebugServerEvents {
                     if (!session) {
                         throw new Error('No active debug session');
                     }
-                    await session.customRequest('continue');
+
+                    // Get the current thread ID (required by DAP spec)
+                    const threads = await session.customRequest('threads');
+                    const threadId = threads.threads[0].id;
+
+                    // Continue with the thread ID
+                    await session.customRequest('continue', { threadId });
                     results.push('Continued execution');
                     break;
                 }


### PR DESCRIPTION
## Summary
The continue command was missing the required `threadId` parameter in its
DAP request arguments, causing Unity's vstuc debug adapter to crash with
a NullReferenceException. 

This fix gets the active thread ID and includes it in continue requests as required by the
Debug Adapter Protocol specification.

### DAP Specification Reference

From the [Debug Adapter Protocol specification](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Continue):

```typescript
interface ContinueArguments {
  /** Continue execution for the specified thread */
  threadId: number;
}
```

The `threadId` parameter is **required**, not optional.

### Tested With
- Unity 6000.0.53f1 with vstuc debugger on VSCode (C# code)